### PR TITLE
Fix command highlight scrolling in spotlight

### DIFF
--- a/app/scripts/spotlight.ts
+++ b/app/scripts/spotlight.ts
@@ -68,7 +68,10 @@ async function openSpotlight() {
   function select(li: HTMLLIElement | null) {
     if (selected) selected.style.background = '';
     selected = li;
-    if (selected) selected.style.background = '#e0e0e0';
+    if (selected) {
+      selected.style.background = '#e0e0e0';
+      selected.scrollIntoView({ block: 'nearest' });
+    }
   }
 
   function render() {


### PR DESCRIPTION
## Summary
- ensure selected command scrolls into view when navigating with arrow keys

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684370b71c088333a984faca63f7e55c