### PR TITLE
Add entity submenu for open record

### DIFF
--- a/app/commands.json
+++ b/app/commands.json
@@ -140,6 +140,11 @@
     "title": "Open record by Id"
   },
   {
+    "id": "refreshEntityMetadata",
+    "category": "",
+    "title": "Refresh entity metadata"
+  },
+  {
     "id": "newRecord",
     "category": "Navigation",
     "title": "New record"

--- a/app/scripts/spotlight.ts
+++ b/app/scripts/spotlight.ts
@@ -59,7 +59,7 @@ async function loadEntityMetadata(force = false): Promise<EntityInfo[]> {
     entityMetadataPromise = Promise.resolve(JSON.parse(cached));
     return entityMetadataPromise;
   }
-  const url = `${window.Xrm?.Page?.context.getClientUrl()}/api/data/v9.1/EntityDefinitions?$select=DisplayName,LogicalName,PrimaryIdAttribute,PrimaryNameAttribute`;
+  const url = `${window.location.origin}/api/data/v9.1/EntityDefinitions?$select=DisplayName,LogicalName,PrimaryIdAttribute,PrimaryNameAttribute`;
   entityMetadataPromise = fetch(url)
     .then((r) => r.json())
     .then((d) =>

--- a/app/scripts/spotlight.ts
+++ b/app/scripts/spotlight.ts
@@ -4,7 +4,19 @@ export interface Command {
   title: string;
 }
 
+interface EntityInfo {
+  logicalName: string;
+  displayName: string;
+}
+
+enum Step {
+  Commands,
+  OpenRecordEntity,
+  OpenRecordId,
+}
+
 let commandsPromise: Promise<Command[]> | null = null;
+let entityMetadataPromise: Promise<EntityInfo[]> | null = null;
 
 export function initSpotlight() {
   document.addEventListener('keydown', async (e) => {
@@ -38,6 +50,29 @@ function fuzzyMatch(query: string, text: string): boolean {
   return true;
 }
 
+async function loadEntityMetadata(force = false): Promise<EntityInfo[]> {
+  if (entityMetadataPromise && !force) return entityMetadataPromise;
+  const cached = localStorage.getItem('dl-entity-metadata');
+  if (cached && !force) {
+    entityMetadataPromise = Promise.resolve(JSON.parse(cached));
+    return entityMetadataPromise;
+  }
+  const url = `${window.Xrm?.Page?.context.getClientUrl()}/api/data/v9.1/EntityDefinitions?$select=LogicalName&$expand=DisplayName($select=UserLocalizedLabel)`;
+  entityMetadataPromise = fetch(url)
+    .then((r) => r.json())
+    .then((d) =>
+      d.value.map((v: any) => ({
+        logicalName: v.LogicalName,
+        displayName: v.DisplayName?.UserLocalizedLabel?.Label || v.LogicalName,
+      }))
+    )
+    .then((list: EntityInfo[]) => {
+      localStorage.setItem('dl-entity-metadata', JSON.stringify(list));
+      return list;
+    });
+  return entityMetadataPromise;
+}
+
 async function openSpotlight() {
   const backdrop = document.createElement('div');
   backdrop.id = 'dl-spotlight-backdrop';
@@ -46,6 +81,8 @@ async function openSpotlight() {
   container.id = 'dl-spotlight-container';
   container.style.cssText =
     'position:absolute;top:20%;left:50%;transform:translateX(-50%);background:rgba(255,255,255,0.75);color:#000;border-radius:12px;padding:16px;width:500px;box-shadow:0 8px 30px rgba(0,0,0,0.2);backdrop-filter:blur(20px);';
+  const pillWrap = document.createElement('div');
+  pillWrap.style.cssText = 'margin-bottom:6px;min-height:24px;';
   const input = document.createElement('input');
   input.type = 'text';
   input.placeholder = 'Search commands...';
@@ -53,7 +90,9 @@ async function openSpotlight() {
     'width:95%;padding:10px 12px;font-size:16px;border:none;outline:none;border-radius:6px;background:rgba(255,255,255,0.6);backdrop-filter:blur(4px);';
   const list = document.createElement('ul');
   list.style.cssText = 'max-height:300px;overflow-y:auto;margin:8px 0 0;padding:0;list-style:none;';
-  container.append(input, list);
+  const progress = document.createElement('progress');
+  progress.style.cssText = 'width:100%;display:none;height:4px;margin-top:6px;';
+  container.append(pillWrap, input, list, progress);
   backdrop.append(container);
   backdrop.addEventListener('click', (e) => {
     if (e.target === backdrop) closeSpotlight();
@@ -62,7 +101,11 @@ async function openSpotlight() {
   input.focus();
 
   const commands = await loadCommands();
-  let filtered = commands;
+  let metadata: EntityInfo[] = [];
+  let filtered: (Command | EntityInfo)[] = commands;
+  let state: Step = Step.Commands;
+  let selectedEntity = '';
+  const pills: string[] = [];
 
   let selected: HTMLLIElement | null = null;
   function select(li: HTMLLIElement | null) {
@@ -74,27 +117,111 @@ async function openSpotlight() {
     }
   }
 
+  function renderPills() {
+    pillWrap.innerHTML = '';
+    pills.forEach((p, idx) => {
+      const span = document.createElement('span');
+      span.textContent = p;
+      span.style.cssText =
+        'display:inline-block;background:#dedede;border-radius:12px;padding:2px 8px;margin-right:4px;font-size:12px;';
+      if (idx === pills.length - 1) {
+        const x = document.createElement('span');
+        x.textContent = ' ×';
+        x.style.cursor = 'pointer';
+        x.addEventListener('click', () => {
+          pills.pop();
+          if (state === Step.OpenRecordId) {
+            state = Step.OpenRecordEntity;
+            input.placeholder = 'Search entity...';
+            filtered = metadata;
+            render();
+          } else {
+            state = Step.Commands;
+            filtered = commands;
+            render();
+          }
+          renderPills();
+        });
+        span.append(x);
+      }
+      pillWrap.append(span);
+    });
+  }
+
   function render() {
     list.innerHTML = '';
-    filtered.slice(0, 20).forEach((cmd) => {
-      const li = document.createElement('li');
-      li.textContent = cmd.title;
-      li.dataset.id = cmd.id;
-      li.dataset.category = cmd.category;
-      li.style.cssText = 'padding:6px 12px;cursor:pointer;border-radius:6px;font-size:14px;';
-      li.addEventListener('mouseenter', () => select(li));
-      li.addEventListener('click', () => executeCommand(cmd));
-      list.append(li);
-    });
+    if (state === Step.Commands) {
+      (filtered as Command[]).slice(0, 20).forEach((cmd) => {
+        const li = document.createElement('li');
+        li.textContent = cmd.title;
+        li.dataset.id = cmd.id;
+        li.dataset.category = cmd.category;
+        li.style.cssText = 'padding:6px 12px;cursor:pointer;border-radius:6px;font-size:14px;';
+        li.addEventListener('mouseenter', () => select(li));
+        li.addEventListener('click', () => executeCommand(cmd));
+        list.append(li);
+      });
+    } else if (state === Step.OpenRecordEntity) {
+      (filtered as EntityInfo[]).slice(0, 20).forEach((ent) => {
+        const li = document.createElement('li');
+        li.innerHTML = `${ent.displayName} <code>${ent.logicalName}</code>`;
+        li.style.cssText =
+          'padding:6px 12px;cursor:pointer;border-radius:6px;font-size:14px;font-family:monospace;background:#fff;';
+        li.addEventListener('mouseenter', () => select(li));
+        li.addEventListener('click', () => {
+          selectedEntity = ent.logicalName;
+          pills.push(ent.displayName);
+          state = Step.OpenRecordId;
+          input.value = '';
+          input.placeholder = 'Record GUID...';
+          list.innerHTML = '';
+          renderPills();
+        });
+        list.append(li);
+      });
+    }
     select(list.firstElementChild as HTMLLIElement | null);
   }
 
-  input.addEventListener('input', () => {
+  input.addEventListener('input', async () => {
     const q = input.value.trim();
-    filtered = q ? commands.filter((c) => fuzzyMatch(q, c.title)) : commands;
+    if (state === Step.Commands) {
+      filtered = q ? commands.filter((c) => fuzzyMatch(q, c.title)) : commands;
+    } else if (state === Step.OpenRecordEntity) {
+      filtered = metadata.filter((m) => fuzzyMatch(q, m.displayName) || fuzzyMatch(q, m.logicalName));
+    }
     render();
   });
-  input.addEventListener('keydown', (e) => {
+  input.addEventListener('keydown', async (e) => {
+    if (state === Step.OpenRecordId && e.key === 'Enter') {
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      if (input.value.trim()) {
+        closeSpotlight();
+        chrome.runtime.sendMessage({
+          type: 'openRecord',
+          category: 'Navigation',
+          content: { entity: selectedEntity, id: input.value.trim() },
+        });
+      }
+      return;
+    }
+
+    if (e.key === 'Backspace' && input.value === '' && pills.length > 0) {
+      pills.pop();
+      if (state === Step.OpenRecordId) {
+        state = Step.OpenRecordEntity;
+        input.placeholder = 'Search entity...';
+        filtered = metadata;
+      } else {
+        state = Step.Commands;
+        filtered = commands;
+      }
+      renderPills();
+      render();
+      return;
+    }
+
     if (e.key === 'ArrowDown') {
       e.preventDefault();
       e.stopImmediatePropagation();
@@ -106,21 +233,44 @@ async function openSpotlight() {
     } else if (e.key === 'Enter') {
       e.preventDefault();
       e.stopImmediatePropagation();
-      if (selected)
+      if (selected && state === Step.Commands) {
         executeCommand({
           id: selected.dataset.id!,
           category: selected.dataset.category!,
           title: selected.textContent || '',
         });
+      } else if (selected && state === Step.OpenRecordEntity) {
+        (selected as HTMLElement).click();
+      }
     }
   });
 
-  render();
-}
+  async function executeCommand(cmd: Command) {
+    if (cmd.id === 'openRecord') {
+      state = Step.OpenRecordEntity;
+      pills.push('Open');
+      progress.style.display = 'block';
+      metadata = await loadEntityMetadata();
+      progress.style.display = 'none';
+      filtered = metadata;
+      input.placeholder = 'Search entity...';
+      input.value = '';
+      renderPills();
+      render();
+      return;
+    } else if (cmd.id === 'refreshEntityMetadata') {
+      progress.style.display = 'block';
+      await loadEntityMetadata(true);
+      progress.style.display = 'none';
+      filtered = commands;
+      render();
+      return;
+    }
+    closeSpotlight();
+    chrome.runtime.sendMessage({ type: cmd.id, category: cmd.category });
+  }
 
-function executeCommand(cmd: Command) {
-  closeSpotlight();
-  chrome.runtime.sendMessage({ type: cmd.id, category: cmd.category });
+  render();
 }
 
 function closeSpotlight() {


### PR DESCRIPTION
## Summary
- support refreshing entity metadata via new command
- add step-based UI in spotlight for opening records
- show pills, progress bar and entity names

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68437303f92483339c8020c7ffbc1b29