### PR TITLE
Improve spotlight module and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 ## Summary
 
-Chrome Extension for Dynamics CRM/365/ Power Apps Power users
+D365-Swiftpad is a productivity extension for Dynamics 365 and Power Apps.
+It is a continuation of the popular LevelUp tool by Natraj Yegnaraman with
+additional commands and a Spotlight style launcher.
+Original authorship belongs to Natraj Yegnaraman with updates by Lovro
+Suhadolnik.
+
+Documentation for developers is available in [docs/development.md](docs/development.md).
 
 ![Level up screenshot](/screenshots/Levelup.png)
 

--- a/app/scripts/background.ts
+++ b/app/scripts/background.ts
@@ -72,11 +72,10 @@ chrome.runtime.onMessage.addListener(async function (
       case 'Impersonation':
         console.log('Handling impersonation response');
         const impersonationResponse = <IImpersonationResponse>message.content;
-        if (impersonationResponse.users.length === 0 || !impersonationResponse.impersonateRequest.canImpersonate)
-          return;
+        if (!impersonationResponse.impersonateRequest.canImpersonate) return;
 
-        // If no URL was provided this is just a search request. Always return the list.
-        if (!impersonationResponse.impersonateRequest.url || impersonationResponse.users.length > 1) {
+        // If more than one result or this is just a search request, return the list
+        if (!impersonationResponse.impersonateRequest.url || impersonationResponse.users.length !== 1) {
           chrome.runtime.sendMessage(<IExtensionMessage>{
             type: 'search',
             category: 'Impersonation',

--- a/app/scripts/background.ts
+++ b/app/scripts/background.ts
@@ -75,7 +75,8 @@ chrome.runtime.onMessage.addListener(async function (
         if (impersonationResponse.users.length === 0 || !impersonationResponse.impersonateRequest.canImpersonate)
           return;
 
-        if (impersonationResponse.users.length > 1) {
+        // If no URL was provided this is just a search request. Always return the list.
+        if (!impersonationResponse.impersonateRequest.url || impersonationResponse.users.length > 1) {
           chrome.runtime.sendMessage(<IExtensionMessage>{
             type: 'search',
             category: 'Impersonation',

--- a/app/scripts/inject/levelup.servicecalls.ts
+++ b/app/scripts/inject/levelup.servicecalls.ts
@@ -199,7 +199,7 @@ export class Service {
           <attribute name='azureactivedirectoryobjectid' />
           <filter>
             <condition attribute='isdisabled' operator='eq' value='0' />
-            condition attribute='islicensed' operator='eq' value='1' />
+            <condition attribute='islicensed' operator='eq' value='1' />
             <condition attribute='accessmode' operator='eq' value='0' />
             <filter type="or">
               ${domainNameCondition}

--- a/app/scripts/spotlight/commands.ts
+++ b/app/scripts/spotlight/commands.ts
@@ -1,3 +1,4 @@
+/** Utility functions for loading and filtering available commands. */
 import { Command } from './types';
 
 let commandsPromise: Promise<Command[]> | null = null;

--- a/app/scripts/spotlight/commands.ts
+++ b/app/scripts/spotlight/commands.ts
@@ -1,0 +1,23 @@
+import { Command } from './types';
+
+let commandsPromise: Promise<Command[]> | null = null;
+
+/** Load list of commands from bundled JSON file */
+export async function loadCommands(): Promise<Command[]> {
+  if (commandsPromise) return commandsPromise;
+  commandsPromise = fetch(chrome.runtime.getURL('app/commands.json')).then((r) => r.json());
+  return commandsPromise;
+}
+
+/** Simple fuzzy search used by spotlight */
+export function fuzzyMatch(query: string, text: string): boolean {
+  query = query.toLowerCase();
+  text = text.toLowerCase();
+  let i = 0;
+  for (const c of query) {
+    i = text.indexOf(c, i);
+    if (i === -1) return false;
+    i++;
+  }
+  return true;
+}

--- a/app/scripts/spotlight/index.ts
+++ b/app/scripts/spotlight/index.ts
@@ -1,0 +1,1 @@
+export { initSpotlight, closeSpotlight } from './ui';

--- a/app/scripts/spotlight/metadata.ts
+++ b/app/scripts/spotlight/metadata.ts
@@ -1,3 +1,4 @@
+/** Fetches and caches entity metadata for the current environment. */
 import { EntityInfo } from './types';
 
 let entityMetadataPromise: Promise<EntityInfo[]> | null = null;

--- a/app/scripts/spotlight/metadata.ts
+++ b/app/scripts/spotlight/metadata.ts
@@ -1,0 +1,41 @@
+import { EntityInfo } from './types';
+
+let entityMetadataPromise: Promise<EntityInfo[]> | null = null;
+const storageKey = `dl-entity-metadata-${location.origin}`;
+
+/**
+ * Load entity metadata and cache it per environment. The first call fetches
+ * metadata from the server and stores it in localStorage. Subsequent calls
+ * return the cached version unless `force` is true.
+ */
+export async function loadEntityMetadata(force = false): Promise<EntityInfo[]> {
+  if (entityMetadataPromise && !force) return entityMetadataPromise;
+
+  const cached = localStorage.getItem(storageKey);
+  if (cached && !force) {
+    const list = JSON.parse(cached) as EntityInfo[];
+    list.sort((a, b) => a.displayName.localeCompare(b.displayName));
+    entityMetadataPromise = Promise.resolve(list);
+    return entityMetadataPromise;
+  }
+
+  const url = `${location.origin}/api/data/v9.1/EntityDefinitions?$select=DisplayName,LogicalName,PrimaryIdAttribute,PrimaryNameAttribute,LogicalCollectionName`;
+  entityMetadataPromise = fetch(url)
+    .then((r) => r.json())
+    .then((d) =>
+      d.value.map((v: any) => ({
+        logicalName: v.LogicalName,
+        displayName: v.DisplayName?.UserLocalizedLabel?.Label || v.LogicalName,
+        primaryIdAttribute: v.PrimaryIdAttribute,
+        primaryNameAttribute: v.PrimaryNameAttribute,
+        logicalCollectionName: v.LogicalCollectionName,
+      }))
+    )
+    .then((list: EntityInfo[]) => {
+      list.sort((a, b) => a.displayName.localeCompare(b.displayName));
+      localStorage.setItem(storageKey, JSON.stringify(list));
+      return list;
+    });
+
+  return entityMetadataPromise;
+}

--- a/app/scripts/spotlight/types.ts
+++ b/app/scripts/spotlight/types.ts
@@ -1,0 +1,36 @@
+export interface Command {
+  id: string;
+  category: string;
+  title: string;
+  icon?: string;
+}
+
+export interface EntityInfo {
+  logicalName: string;
+  displayName: string;
+  primaryIdAttribute: string;
+  primaryNameAttribute: string;
+  logicalCollectionName: string;
+}
+
+export interface UserInfo {
+  userId: string;
+  userName: string;
+  fullName: string;
+}
+
+export enum Step {
+  Commands,
+  OpenRecordEntity,
+  OpenRecordId,
+  ImpersonateSearch,
+  FetchXml,
+  EntityInfoDisplay,
+}
+
+export interface SpotlightState {
+  query: string;
+  state: Step;
+  pills: string[];
+  selectedEntity: string;
+}

--- a/app/scripts/spotlight/ui.ts
+++ b/app/scripts/spotlight/ui.ts
@@ -243,6 +243,8 @@ async function openSpotlight(options?: { tip?: boolean }) {
         state = Step.OpenRecordId;
         input.value = '';
         input.placeholder = 'Enter GUID or start typing the name of the entity';
+        recordResults = [];
+        filtered = recordResults;
         list.innerHTML = '';
         renderPills();
         render();
@@ -267,6 +269,8 @@ async function openSpotlight(options?: { tip?: boolean }) {
           state = Step.OpenRecordId;
           input.value = '';
           input.placeholder = 'Enter GUID or start typing the name of the entity';
+          recordResults = [];
+          filtered = recordResults;
           list.innerHTML = '';
           renderPills();
           render();

--- a/app/scripts/spotlight/ui.ts
+++ b/app/scripts/spotlight/ui.ts
@@ -447,9 +447,9 @@ async function openSpotlight(options?: { tip?: boolean }) {
       list.style.display = 'none';
       infoPanel.style.display = 'block';
       infoPanel.innerHTML =
-        '<div style="font-weight:bold;margin-bottom:4px;">FetchXML Runner</div>' +
-        '<textarea id="dl-fetchxml" style="width:100%;height:80px;\"></textarea>' +
-        '<div style="font-size:12px;margin-top:4px;">Press Ctrl+Enter to run</div>';
+        '<div class="dl-fetchxml-header">FetchXML Runner</div>' +
+        '<textarea id="dl-fetchxml"></textarea>' +
+        '<div class="dl-fetchxml-help">Press Ctrl+Enter to run</div>';
       input.style.display = 'none';
       const textarea = infoPanel.querySelector<HTMLTextAreaElement>('textarea')!;
       textarea.focus();

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -1,0 +1,138 @@
+#dl-spotlight-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.3);
+  z-index: 2147483647;
+}
+
+#dl-spotlight-container {
+  position: absolute;
+  top: 20%;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(255, 255, 255, 0.45);
+  color: #000;
+  border-radius: 12px;
+  padding: 16px;
+  width: 500px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.2);
+  backdrop-filter: blur(9px);
+}
+
+#dl-spotlight-logo {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  height: 32px;
+}
+
+#dl-spotlight-pills {
+  margin-bottom: 6px;
+  min-height: 24px;
+}
+
+#dl-spotlight-input {
+  width: 95%;
+  padding: 10px 12px;
+  font-size: 16px;
+  border: none;
+  outline: none;
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.4);
+  backdrop-filter: blur(4px);
+}
+
+#dl-spotlight-list {
+  max-height: 300px;
+  overflow-y: auto;
+  margin: 8px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+#dl-spotlight-info {
+  display: none;
+  margin-top: 8px;
+  font-size: 14px;
+  background: #f7f7f7;
+  padding: 8px;
+  border-radius: 6px;
+}
+
+#dl-spotlight-progress {
+  display: none;
+  text-align: center;
+  margin-top: 6px;
+}
+
+.dl-pill {
+  display: inline-block;
+  background: #dedede;
+  border-radius: 12px;
+  padding: 2px 8px;
+  margin-right: 4px;
+  font-size: 12px;
+}
+
+.dl-listitem {
+  padding: 6px 12px;
+  cursor: pointer;
+  border-radius: 6px;
+  font-size: 14px;
+  display: flex;
+  align-items: center;
+}
+
+.dl-selected {
+  background: #e0e0e0;
+}
+
+.dl-command-icon {
+  margin-right: 8px;
+  color: #a631af;
+  font-size: 15px;
+}
+
+.dl-code {
+  background: #f0f0f0;
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-family: monospace;
+}
+
+.dl-spinner {
+  display: block;
+  margin: 0 auto;
+  border: 4px solid #f3f3f3;
+  border-top: 4px solid #555;
+  border-radius: 50%;
+  width: 24px;
+  height: 24px;
+  animation: dl-spin 1s linear infinite;
+}
+
+.dl-progress-text {
+  font-size: 12px;
+  color: #555;
+  margin-top: 4px;
+}
+
+.dl-tip {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #555;
+  text-align: right;
+}
+
+.dl-muted {
+  color: #555;
+}
+
+@keyframes dl-spin {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -128,6 +128,22 @@
   color: #555;
 }
 
+/* FetchXML runner styles */
+#dl-fetchxml {
+  width: 100%;
+  height: 80px;
+}
+
+.dl-fetchxml-header {
+  font-weight: bold;
+  margin-bottom: 4px;
+}
+
+.dl-fetchxml-help {
+  font-size: 12px;
+  margin-top: 4px;
+}
+
 @keyframes dl-spin {
   0% {
     transform: rotate(0deg);

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,13 @@
+# Developing Commands
+
+Commands shown in the spotlight are defined in `app/commands.json`. Each entry contains a unique `id`, a category and the text displayed to the user.
+
+When spotlight executes a command it sends a message with this `id` to the background script. The background script or injected scripts implement the behaviour.
+
+To add a new command:
+
+1. Add an object to `app/commands.json` with a new `id`, `category` and `title`.
+2. Handle the command in the appropriate script. Most UI related logic lives in `app/scripts/inject` while navigation and background tasks are handled in `app/scripts/background.ts`.
+3. Rebuild the extension with `npm run build`.
+
+The TypeScript sources are organised under `app/scripts`. Spotlight related code is in `app/scripts/spotlight`.

--- a/manifest.json
+++ b/manifest.json
@@ -15,36 +15,22 @@
   "description": "Navigate Dynamics as fast as YOU want.",
   "content_scripts": [
     {
-      "matches": [
-        "http://*/*",
-        "https://*/*"
-      ],
-      "js": [
-        "app/scripts/app.ts"
-      ]
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["app/scripts/app.ts"]
     }
   ],
-  "host_permissions": [
-    "*://*.dynamics.com/api/*",
-    "*://*.dynamics.com.mcas.ms/*"
-  ],
-  "permissions": [
-    "scripting",
-    "storage",
-    "activeTab",
-    "declarativeNetRequest"
-  ],
+  "host_permissions": ["*://*.dynamics.com/api/*", "*://*.dynamics.com.mcas.ms/*"],
+  "permissions": ["scripting", "storage", "activeTab", "declarativeNetRequest"],
   "web_accessible_resources": [
     {
       "resources": [
         "app/libraries/Sdk.Soap.min.js",
         "app/scripts/levelup.extension.js",
         "app/commands.json",
-        "app/images/lp_ll.png"
+        "app/images/lp_ll.png",
+        "app/styles/spotlight.css"
       ],
-      "matches": [
-        "<all_urls>"
-      ]
+      "matches": ["<all_urls>"]
     }
   ],
   "icons": {


### PR DESCRIPTION
## Summary
- refactor spotlight into a folder of smaller modules
- cache entity metadata per environment
- allow opening an entity list with a double click or pressing Enter
- improve documentation and add a developer guide

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844301b82708333be62a7500391ffb6