### PR TITLE
Fix user role and metadata commands

### DIFF
--- a/app/commands.json
+++ b/app/commands.json
@@ -58,7 +58,7 @@
   },
   {
     "id": "myMailbox",
-    "category": "",
+    "category": "Navigation",
     "title": "My Mailbox"
   },
   {

--- a/app/scripts/inject/levelup.forms.ts
+++ b/app/scripts/inject/levelup.forms.ts
@@ -487,9 +487,8 @@ export class Forms {
 
   private showToast(message: string) {
     const toast = this.utility.formDocument.createElement('div');
+    toast.className = 'dl-toast';
     toast.textContent = message;
-    toast.style.cssText =
-      'position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:#323232;color:#fff;padding:8px 16px;border-radius:4px;z-index:2147483647;opacity:0;transition:opacity 0.3s;';
     this.utility.formDocument.body.append(toast);
     requestAnimationFrame(() => {
       toast.style.opacity = '1';

--- a/app/scripts/inject/levelup.forms.ts
+++ b/app/scripts/inject/levelup.forms.ts
@@ -122,7 +122,7 @@ export class Forms {
       }etn=${this.utility.Xrm.Page.data.entity.getEntityName()}&id=${entityId}&newWindow=true&pagetype=entityrecord`;
       try {
         Utility.copy(locationUrl);
-        alert('Record URL has been copied to clipboard');
+        this.showToast('Record URL has been copied to clipboard');
       } catch (e) {
         prompt('Ctrl+C to copy. OK to close.', locationUrl);
       }
@@ -136,7 +136,7 @@ export class Forms {
     if (entityId) {
       try {
         Utility.copy(entityId.substr(1, 36));
-        alert('Record Id has been copied to clipboard');
+        this.showToast('Record Id has been copied to clipboard');
       } catch (e) {
         prompt('Ctrl+C to copy. OK to close.', entityId);
       }
@@ -483,6 +483,21 @@ export class Forms {
 
   resetBlur() {
     setFilter(this.utility.Xrm.Page.getAttribute(), this.utility.formDocument, '');
+  }
+
+  private showToast(message: string) {
+    const toast = this.utility.formDocument.createElement('div');
+    toast.textContent = message;
+    toast.style.cssText =
+      'position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:#323232;color:#fff;padding:8px 16px;border-radius:4px;z-index:2147483647;opacity:0;transition:opacity 0.3s;';
+    this.utility.formDocument.body.append(toast);
+    requestAnimationFrame(() => {
+      toast.style.opacity = '1';
+    });
+    setTimeout(() => {
+      toast.style.opacity = '0';
+      toast.addEventListener('transitionend', () => toast.remove());
+    }, 2000);
   }
 }
 

--- a/app/scripts/inject/levelup.navigation.ts
+++ b/app/scripts/inject/levelup.navigation.ts
@@ -221,9 +221,8 @@ export class Navigation {
 
   private showToast(message: string) {
     const toast = document.createElement('div');
+    toast.className = 'dl-toast';
     toast.textContent = message;
-    toast.style.cssText =
-      'position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:#323232;color:#fff;padding:8px 16px;border-radius:4px;z-index:2147483647;opacity:0;transition:opacity 0.3s;';
     document.body.append(toast);
     requestAnimationFrame(() => {
       toast.style.opacity = '1';

--- a/app/scripts/interfaces/types.ts
+++ b/app/scripts/interfaces/types.ts
@@ -40,13 +40,17 @@ export type MessageType =
   | 'quickFindFields'
   | 'environmentDetails'
   | 'myRoles'
+  | 'myRolesRequest'
+  | 'myRolesResponse'
   | 'allUserRoles'
   | 'processes'
   | 'loadUsers'
   | 'activation'
   | 'reset'
   | 'search'
-  | 'impersonation';
+  | 'impersonation'
+  | 'entityMetadataRequest'
+  | 'entityMetadataResponse';
 
 export type Category =
   | 'Impersonation'

--- a/app/scripts/levelup.extension.ts
+++ b/app/scripts/levelup.extension.ts
@@ -78,6 +78,19 @@ window.addEventListener('message', async function (event) {
           const impersonateMessage = <IImpersonateMessage>message.content;
           new Service(utility).impersonateUser(impersonateMessage);
           break;
+        case 'myRolesRequest':
+          {
+            const roles = await new Service(utility).getMyRolesData();
+            window.postMessage({ type: 'myRolesResponse', content: roles }, '*');
+          }
+          break;
+        case 'entityMetadataRequest':
+          {
+            const entity = message.content as string;
+            const meta = await new Service(utility).getEntityMetadataData(entity);
+            window.postMessage({ type: 'entityMetadataResponse', content: meta }, '*');
+          }
+          break;
         case 'myRoles':
         case 'allUserRoles':
         case 'entityMetadata':

--- a/app/scripts/levelup.extension.ts
+++ b/app/scripts/levelup.extension.ts
@@ -78,6 +78,15 @@ window.addEventListener('message', async function (event) {
           const impersonateMessage = <IImpersonateMessage>message.content;
           new Service(utility).impersonateUser(impersonateMessage);
           break;
+        case 'myRoles':
+        case 'allUserRoles':
+        case 'entityMetadata':
+        case 'environment':
+        case 'optionsets':
+        case 'workflows':
+        case 'allFields':
+          new Service(utility)[message.type]();
+          break;
       }
     } catch (e) {
       console.error('Levelup message execution failed', e);

--- a/app/scripts/spotlight/controller.ts
+++ b/app/scripts/spotlight/controller.ts
@@ -1,0 +1,30 @@
+export interface RoleInfo {
+  name: string;
+  roleid: string;
+}
+
+export function requestRoles(): Promise<RoleInfo[]> {
+  return new Promise((resolve) => {
+    const handler = (ev: MessageEvent) => {
+      if (ev.data?.type === 'myRolesResponse') {
+        window.removeEventListener('message', handler);
+        resolve(ev.data.content as RoleInfo[]);
+      }
+    };
+    window.addEventListener('message', handler);
+    window.postMessage({ type: 'myRolesRequest' }, '*');
+  });
+}
+
+export function requestEntityMetadata(entity: string): Promise<Record<string, any>> {
+  return new Promise((resolve) => {
+    const handler = (ev: MessageEvent) => {
+      if (ev.data?.type === 'entityMetadataResponse') {
+        window.removeEventListener('message', handler);
+        resolve(ev.data.content as Record<string, any>);
+      }
+    };
+    window.addEventListener('message', handler);
+    window.postMessage({ type: 'entityMetadataRequest', content: entity }, '*');
+  });
+}

--- a/app/scripts/spotlight/state.ts
+++ b/app/scripts/spotlight/state.ts
@@ -1,0 +1,12 @@
+import { Step } from './types';
+
+export interface SpotlightState {
+  query: string;
+  state: Step;
+  pills: string[];
+  selectedEntity: string;
+}
+
+export function initialState(): SpotlightState {
+  return { query: '', state: Step.Commands, pills: [], selectedEntity: '' };
+}

--- a/app/scripts/spotlight/types.ts
+++ b/app/scripts/spotlight/types.ts
@@ -28,10 +28,3 @@ export enum Step {
   EntityInfoDisplay,
   EnvironmentInfoDisplay,
 }
-
-export interface SpotlightState {
-  query: string;
-  state: Step;
-  pills: string[];
-  selectedEntity: string;
-}

--- a/app/scripts/spotlight/ui.ts
+++ b/app/scripts/spotlight/ui.ts
@@ -539,6 +539,7 @@ async function openSpotlight(options?: { tip?: boolean }) {
     } else if (cmd.id === 'myRoles') {
       state = Step.EnvironmentInfoDisplay;
       pills.push('Roles');
+      infoPanel.innerHTML = '';
       progressText.textContent = 'Loading roles...';
       progress.style.display = 'block';
       try {
@@ -554,7 +555,11 @@ async function openSpotlight(options?: { tip?: boolean }) {
             (r: any) =>
               `<div class="dl-info-row">${r.name}: <span class="dl-copy dl-code" data-val="${r.roleid}">${r.roleid}</span></div>`
           );
-          infoPanel.innerHTML = `<div class="dl-copy-hint">Click to Copy</div>${rows.join('')}`;
+          if (rows.length) {
+            infoPanel.innerHTML = `<div class="dl-copy-hint">Click to Copy</div>${rows.join('')}`;
+          } else {
+            infoPanel.textContent = 'No security roles found';
+          }
           input.style.display = 'none';
           infoPanel.querySelectorAll<HTMLSpanElement>('.dl-copy').forEach((el) => {
             el.addEventListener('click', () => {
@@ -570,6 +575,8 @@ async function openSpotlight(options?: { tip?: boolean }) {
               showToast('Copied to Clipboard');
             });
           });
+        } else {
+          infoPanel.textContent = 'No security roles found';
         }
       } finally {
         progress.style.display = 'none';

--- a/app/scripts/spotlight/ui.ts
+++ b/app/scripts/spotlight/ui.ts
@@ -542,7 +542,10 @@ async function openSpotlight(options?: { tip?: boolean }) {
       progressText.textContent = 'Loading roles...';
       progress.style.display = 'block';
       try {
-        const ids = (window as any).Xrm?.Page?.context?.getUserRoles?.() || [];
+        const ids =
+          (window as any).Xrm?.Utility?.getGlobalContext?.()?.userSettings?.securityRoles ||
+          (window as any).Xrm?.Page?.context?.getUserRoles?.() ||
+          [];
         if (ids.length) {
           const filter = ids.map((id: string) => `roleid eq ${id}`).join(' or ');
           const resp = await fetch(`${location.origin}/api/data/v9.1/roles?$select=name,roleid&$filter=${filter}`);
@@ -581,7 +584,10 @@ async function openSpotlight(options?: { tip?: boolean }) {
     } else if (cmd.id === 'entityMetadata') {
       state = Step.EnvironmentInfoDisplay;
       pills.push('Metadata');
-      const entity = (window as any).Xrm?.Page?.data?.entity?.getEntityName?.() || '';
+      const entity =
+        (window as any).Xrm?.Page?.data?.entity?.getEntityName?.() ||
+        (window as any).Xrm?.Utility?.getPageContext?.()?.input?.entityName ||
+        '';
       if (!entity) {
         showToast('No entity context');
         return;

--- a/app/scripts/spotlight/ui.ts
+++ b/app/scripts/spotlight/ui.ts
@@ -421,6 +421,16 @@ async function openSpotlight(options?: { tip?: boolean }) {
     } else if (ev.key === 'ArrowUp') {
       select((selected?.previousElementSibling as HTMLLIElement) || list.lastElementChild);
       ev.preventDefault();
+    } else if (ev.key === 'Backspace' && input.value === '' && state === Step.EnvironmentInfoDisplay) {
+      pills.pop();
+      state = Step.Commands;
+      filtered = commands;
+      input.placeholder = 'Search commands...';
+      input.style.display = '';
+      infoPanel.style.display = 'none';
+      list.style.display = '';
+      renderPills();
+      render();
     } else if (ev.key === 'Enter') {
       if (selected && state === Step.Commands) {
         const id = selected.dataset.id!;
@@ -549,7 +559,10 @@ async function openSpotlight(options?: { tip?: boolean }) {
           [];
         if (ids.length) {
           const filter = ids.map((id: string) => `roleid eq ${id}`).join(' or ');
-          const resp = await fetch(`${location.origin}/api/data/v9.1/roles?$select=name,roleid&$filter=${filter}`);
+          const version = (window as any).Xrm?.Utility?.getGlobalContext?.()?.getVersion?.()?.substring(0, 3) || '9.1';
+          const resp = await fetch(
+            `${location.origin}/api/data/v${version}/roles?$select=name,roleid&$filter=${encodeURIComponent(filter)}`
+          );
           const data = await resp.json();
           const rows = (data.value || []).map(
             (r: any) =>

--- a/app/scripts/spotlight/utils.ts
+++ b/app/scripts/spotlight/utils.ts
@@ -1,0 +1,24 @@
+export function showToast(message: string, doc: Document = document) {
+  const toast = doc.createElement('div');
+  toast.className = 'dl-toast';
+  toast.textContent = message;
+  doc.body.append(toast);
+  requestAnimationFrame(() => {
+    toast.style.opacity = '1';
+  });
+  setTimeout(() => {
+    toast.style.opacity = '0';
+    toast.addEventListener('transitionend', () => toast.remove());
+  }, 2000);
+}
+
+export function el<K extends keyof HTMLElementTagNameMap>(
+  tag: K,
+  className?: string,
+  text?: string
+): HTMLElementTagNameMap[K] {
+  const node = document.createElement(tag);
+  if (className) node.className = className;
+  if (text) node.textContent = text;
+  return node;
+}

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -177,3 +177,17 @@
     transform: rotate(360deg);
   }
 }
+
+.dl-toast {
+  position: fixed;
+  bottom: 20px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: #323232;
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 4px;
+  z-index: 2147483647;
+  opacity: 0;
+  transition: opacity 0.3s;
+}

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -93,10 +93,13 @@
 }
 
 .dl-code {
-  border: 1px solid #ccc;
+  border: 1px solid #afafaf;
   padding: 2px 4px;
   border-radius: 4px;
   font-family: monospace;
+  color: #771899;
+  background: #ffffff40;
+  margin: 0 5px 0 5px;
 }
 
 .dl-spinner {

--- a/docs/development.md
+++ b/docs/development.md
@@ -11,3 +11,14 @@ To add a new command:
 3. Rebuild the extension with `npm run build`.
 
 The TypeScript sources are organised under `app/scripts`. Spotlight related code is in `app/scripts/spotlight`.
+
+## Debug builds
+
+Vite removes `debugger` statements when minifying. To keep them during a build,
+set the environment variable `KEEP_DEBUG=true`:
+
+```bash
+KEEP_DEBUG=true npm run build
+```
+
+The resulting code will retain `debugger` statements and include source maps.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">=20"
   },
   "scripts": {
-    "dev": "vite",
+    "dev": "npm run prebuild && vite",
     "prebuild": "esbuild app/scripts/levelup.extension.ts --bundle --outfile=app/scripts/levelup.extension.js --platform=browser --format=esm && esbuild app/scripts/grid.ts --bundle --outfile=app/scripts/grid.js --platform=browser --format=esm && esbuild app/scripts/pages/organisationdetails.ts --bundle --outfile=app/scripts/organisationdetails.js --platform=browser --format=esm && esbuild app/scripts/pages/processes.ts --bundle --outfile=app/scripts/processes.js --platform=browser --format=esm && esbuild app/scripts/pages/userroles.ts --bundle --outfile=app/scripts/userroles.js --platform=browser --format=esm && esbuild app/scripts/pages/optionsets.ts --bundle --outfile=app/scripts/optionsets.js --platform=browser --format=esm",
     "build": "vite build",
     "postbuild": "rimraf app/scripts/levelup.extension.js app/scripts/grid.js app/scripts/organisationdetails.js app/scripts/processes.js app/scripts/userroles.js app/scripts/optionsets.js",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,9 +3,13 @@ import { crx } from '@crxjs/vite-plugin';
 import manifest from './manifest.json';
 import { resolve } from 'path';
 
+const keepDebug = process.env.KEEP_DEBUG === 'true';
+
 export default defineConfig({
   build: {
+    minify: keepDebug ? false : 'esbuild',
     outDir: 'dist',
+    esbuild: keepDebug ? {} : { drop: ['debugger'] },
     rollupOptions: {
       input: {
         options: resolve(__dirname, 'app/pages/options.html'),


### PR DESCRIPTION
## Summary
- route several categories to service calls
- show toast instead of alerts for copy commands
- support My Mailbox navigation category
- display My Roles and Entity Metadata inline

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684499018ffc8333bbc91eeacee38d40