### PR TITLE
Add Auto Reload command

### DIFF
--- a/app/commands.json
+++ b/app/commands.json
@@ -35,7 +35,6 @@
     "title": "Run FetchXML"
   },
 
-
   {
     "id": "environmentDetails",
     "category": "",
@@ -66,7 +65,7 @@
     "category": "",
     "title": "Entity Metadata"
   },
-  
+
   {
     "id": "clearLogicalNames",
     "category": "Forms",
@@ -82,8 +81,7 @@
     "category": "Forms",
     "title": "Reset Blur"
   },
-  
-  
+
   {
     "id": "highlightDirtyFields",
     "category": "Forms",
@@ -114,7 +112,7 @@
     "category": "Forms",
     "title": "Minimum values"
   },
-  
+
   {
     "id": "cloneRecord",
     "category": "Forms",
@@ -215,8 +213,7 @@
     "category": "sendToFXB",
     "title": "Open View in FetchXML Builder"
   },
-  
-  
+
   {
     "id": "impersonationResetSpotlight",
     "category": "Impersonation",
@@ -241,5 +238,10 @@
     "id": "reloadData",
     "category": "Navigation",
     "title": "Reload Data"
+  },
+  {
+    "id": "autoReload",
+    "category": "Navigation",
+    "title": "Auto Reload"
   }
 ]

--- a/app/scripts/inject/levelup.navigation.ts
+++ b/app/scripts/inject/levelup.navigation.ts
@@ -208,11 +208,14 @@ export class Navigation {
     const title = document.createElement('span');
     title.textContent = 'Auto refresh';
     title.style.marginRight = '8px';
+    const indicator = document.createElement('div');
+    indicator.className = 'dl-indicator';
     const spinner = document.createElement('div');
     spinner.className = 'dl-spinner';
     const tick = document.createElement('span');
     tick.textContent = '✓';
     tick.className = 'dl-tick';
+    indicator.append(spinner, tick);
     const btnWrap = document.createElement('div');
     btnWrap.style.display = 'flex';
     btnWrap.style.gap = '4px';
@@ -242,17 +245,16 @@ export class Navigation {
         this.autoReloadSelected.classList.remove('selected');
         this.autoReloadSelected = null;
       }
+      toast.remove();
     });
     btnWrap.append(stopBtn);
-    toast.append(title, spinner, tick, btnWrap);
+    toast.append(title, indicator, btnWrap);
     document.body.append(toast);
 
     const showTick = () => {
-      spinner.style.display = 'none';
-      tick.style.display = 'flex';
+      tick.style.opacity = '1';
       setTimeout(() => {
-        tick.style.display = 'none';
-        spinner.style.display = 'block';
+        tick.style.opacity = '0';
       }, 500);
     };
 

--- a/app/scripts/inject/levelup.navigation.ts
+++ b/app/scripts/inject/levelup.navigation.ts
@@ -189,6 +189,75 @@ export class Navigation {
     window.location.reload();
   }
 
+  private autoReloadTimer: number | null = null;
+
+  autoReload() {
+    const existing = document.getElementById('dl-auto-reload-toast');
+    if (existing) {
+      if (this.autoReloadTimer) clearInterval(this.autoReloadTimer);
+      existing.remove();
+      this.autoReloadTimer = null;
+      return;
+    }
+
+    const toast = document.createElement('div');
+    toast.id = 'dl-auto-reload-toast';
+    toast.style.cssText =
+      'position:fixed;bottom:20px;left:20px;background:#323232;color:#fff;padding:8px 16px;border-radius:4px;z-index:2147483647;display:flex;align-items:center;gap:8px;font-size:12px;';
+    const spinner = document.createElement('div');
+    spinner.className = 'dl-spinner';
+    const tick = document.createElement('span');
+    tick.textContent = '✓';
+    tick.style.display = 'none';
+    const btnWrap = document.createElement('div');
+    btnWrap.style.display = 'flex';
+    btnWrap.style.gap = '4px';
+    [
+      { label: '1s', ms: 1000 },
+      { label: '5s', ms: 5000 },
+      { label: '10s', ms: 10000 },
+    ].forEach((b) => {
+      const btn = document.createElement('button');
+      btn.textContent = b.label;
+      btn.style.cssText = 'background:#555;border:none;color:#fff;padding:2px 4px;border-radius:2px;cursor:pointer;';
+      btn.addEventListener('click', () => setFreq(b.ms));
+      btnWrap.append(btn);
+    });
+    toast.append(spinner, tick, btnWrap);
+    document.body.append(toast);
+
+    const showTick = () => {
+      spinner.style.display = 'none';
+      tick.style.display = 'inline';
+      setTimeout(() => {
+        tick.style.display = 'none';
+        spinner.style.display = 'block';
+      }, 500);
+    };
+
+    const reload = () => {
+      //@ts-ignore
+      if (Xrm.Page?.data?.refresh) {
+        //@ts-ignore
+        const result = Xrm.Page.data.refresh(false);
+        if (result && result.then) {
+          result.then(showTick);
+        } else {
+          showTick();
+        }
+        return;
+      }
+      window.location.reload();
+    };
+
+    const setFreq = (ms: number) => {
+      if (this.autoReloadTimer) clearInterval(this.autoReloadTimer);
+      this.autoReloadTimer = window.setInterval(reload, ms);
+    };
+
+    setFreq(5000);
+  }
+
   solutionHistory() {
     if (
       //@ts-ignore

--- a/app/scripts/inject/levelup.navigation.ts
+++ b/app/scripts/inject/levelup.navigation.ts
@@ -190,6 +190,7 @@ export class Navigation {
   }
 
   private autoReloadTimer: number | null = null;
+  private autoReloadSelected: HTMLButtonElement | null = null;
 
   autoReload() {
     const existing = document.getElementById('dl-auto-reload-toast');
@@ -204,14 +205,19 @@ export class Navigation {
     toast.id = 'dl-auto-reload-toast';
     toast.style.cssText =
       'position:fixed;bottom:20px;left:20px;background:#323232;color:#fff;padding:8px 16px;border-radius:4px;z-index:2147483647;display:flex;align-items:center;gap:8px;font-size:12px;';
+    const title = document.createElement('span');
+    title.textContent = 'Auto refresh';
+    title.style.marginRight = '8px';
     const spinner = document.createElement('div');
     spinner.className = 'dl-spinner';
     const tick = document.createElement('span');
     tick.textContent = '✓';
-    tick.style.display = 'none';
+    tick.className = 'dl-tick';
     const btnWrap = document.createElement('div');
     btnWrap.style.display = 'flex';
     btnWrap.style.gap = '4px';
+    let defaultBtn: HTMLButtonElement | null = null;
+    const buttonStyle = 'background:#555;border:none;color:#fff;padding:2px 4px;border-radius:2px;cursor:pointer;';
     [
       { label: '1s', ms: 1000 },
       { label: '5s', ms: 5000 },
@@ -219,16 +225,31 @@ export class Navigation {
     ].forEach((b) => {
       const btn = document.createElement('button');
       btn.textContent = b.label;
-      btn.style.cssText = 'background:#555;border:none;color:#fff;padding:2px 4px;border-radius:2px;cursor:pointer;';
-      btn.addEventListener('click', () => setFreq(b.ms));
+      btn.style.cssText = buttonStyle;
+      btn.addEventListener('click', () => setFreq(b.ms, btn));
       btnWrap.append(btn);
+      if (b.ms === 5000) defaultBtn = btn;
     });
-    toast.append(spinner, tick, btnWrap);
+    const stopBtn = document.createElement('button');
+    stopBtn.textContent = 'Stop';
+    stopBtn.style.cssText = buttonStyle;
+    stopBtn.addEventListener('click', () => {
+      if (this.autoReloadTimer) {
+        clearInterval(this.autoReloadTimer);
+        this.autoReloadTimer = null;
+      }
+      if (this.autoReloadSelected) {
+        this.autoReloadSelected.classList.remove('selected');
+        this.autoReloadSelected = null;
+      }
+    });
+    btnWrap.append(stopBtn);
+    toast.append(title, spinner, tick, btnWrap);
     document.body.append(toast);
 
     const showTick = () => {
       spinner.style.display = 'none';
-      tick.style.display = 'inline';
+      tick.style.display = 'flex';
       setTimeout(() => {
         tick.style.display = 'none';
         spinner.style.display = 'block';
@@ -250,12 +271,19 @@ export class Navigation {
       window.location.reload();
     };
 
-    const setFreq = (ms: number) => {
+    const setFreq = (ms: number, btn?: HTMLButtonElement) => {
       if (this.autoReloadTimer) clearInterval(this.autoReloadTimer);
       this.autoReloadTimer = window.setInterval(reload, ms);
+      if (this.autoReloadSelected) {
+        this.autoReloadSelected.classList.remove('selected');
+      }
+      if (btn) {
+        btn.classList.add('selected');
+        this.autoReloadSelected = btn;
+      }
     };
 
-    setFreq(5000);
+    setFreq(5000, defaultBtn);
   }
 
   solutionHistory() {

--- a/app/scripts/interfaces/types.ts
+++ b/app/scripts/interfaces/types.ts
@@ -36,6 +36,7 @@ export type MessageType =
   | 'openAdmin'
   | 'openMakePowerApps'
   | 'reloadData'
+  | 'autoReload'
   | 'openGrid'
   | 'quickFindFields'
   | 'environmentDetails'

--- a/app/scripts/spotlight/ui.ts
+++ b/app/scripts/spotlight/ui.ts
@@ -15,6 +15,7 @@ const commandIcons: Record<string, string> = {
   openMakePowerApps: 'open_in_new',
   entityInfoSpotlight: 'info',
   reloadData: 'refresh',
+  autoReload: 'autorenew',
   runFetchXmlSpotlight: 'code',
 };
 

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -178,3 +178,20 @@
 #dl-auto-reload-toast button {
   font-size: 12px;
 }
+
+#dl-auto-reload-toast .dl-spinner,
+#dl-auto-reload-toast .dl-tick {
+  width: 24px;
+  height: 24px;
+}
+
+#dl-auto-reload-toast .dl-tick {
+  display: none;
+  font-size: 20px;
+  align-items: center;
+  justify-content: center;
+}
+
+#dl-auto-reload-toast button.selected {
+  background: #777;
+}

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -179,19 +179,29 @@
   font-size: 12px;
 }
 
-#dl-auto-reload-toast .dl-spinner,
-#dl-auto-reload-toast .dl-tick {
+#dl-auto-reload-toast .dl-indicator {
+  position: relative;
   width: 24px;
   height: 24px;
 }
 
-#dl-auto-reload-toast .dl-tick {
-  display: none;
-  font-size: 20px;
+#dl-auto-reload-toast .dl-indicator .dl-spinner,
+#dl-auto-reload-toast .dl-indicator .dl-tick {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 24px;
+  height: 24px;
+}
+
+#dl-auto-reload-toast .dl-indicator .dl-tick {
+  display: flex;
   align-items: center;
   justify-content: center;
+  font-size: 20px;
+  opacity: 0;
 }
 
 #dl-auto-reload-toast button.selected {
-  background: #777;
+  background: #777 !important;
 }

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -174,3 +174,7 @@
     transform: rotate(360deg);
   }
 }
+
+#dl-auto-reload-toast button {
+  font-size: 12px;
+}


### PR DESCRIPTION
## Summary
- add `autoReload` command configuration
- show icon mapping in spotlight
- implement autoReload timer UI and logic
- include autopreload CSS styling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6844a8ae05208333be8e85dc8cb83772