### PR TITLE
Add CI workflow for releases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,72 +1,37 @@
-# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: build
+name: Build Extension
 
 on:
+  push:
+    tags:
+      - 'v*'
   workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag'
-        default: false
-      draftRelease:
-        description: 'Draft Release'
-        default: false
+
 jobs:
   build:
-
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [16.x]
     env:
-      filename: levelup-for-dynamics-365-power-apps
+      PACKAGE_NAME: d365-swiftpad
 
     steps:
-    - uses: actions/checkout@v3
-
-    - name: Cache node modules
-      id: cache-npm
-      uses: actions/cache@v3
-      env:
-        cache-name: cache-node-modules
-      with:
-        # npm cache files are stored in `~/.npm` on Linux/macOS
-        path: ~/.npm
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
-
-    - if: ${{ steps.cache-npm.outputs.cache-hit != 'true' }}
-      name: List the state of node modules
-      continue-on-error: true
-      run: npm list
-
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v3.6.0
-      with:
-        node-version: ${{ matrix.node-version }}
-
-    - name: Read package.json
-      uses: tyankatsu0105/read-package-version-actions@v1
-      id: package-version
-
-    - run: npm ci
-
-    - run: npm run pack
-
-    - name: Create Release ${{ env.filename }}-${{ steps.package-version.outputs.version }}
-      id: create-draft-release
-      uses: ncipollo/release-action@v1.12.0
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        name: ${{ env.filename }}-${{ steps.package-version.outputs.version }}
-        draft: github.event.inputs.draftRelease
-        prerelease: github.event.inputs.draftRelease
-        artifacts: "./packages/${{ env.filename }}-${{ steps.package-version.outputs.version }}-chrome.zip"
-        replacesArtifacts: true
-        tag: ${{ github.event.inputs.tag }}
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+      - name: Package extension
+        run: |
+          mkdir -p packages
+          cd dist
+          zip -r "../packages/${PACKAGE_NAME}-${{ github.ref_name }}-chrome.zip" .
+          cd ..
+      - name: Create Release
+        uses: ncipollo/release-action@v1.12.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: ${{ github.ref_name }}
+          artifacts: "packages/${{ env.PACKAGE_NAME }}-${{ github.ref_name }}-chrome.zip"
+          tag: ${{ github.ref_name }}
+          replacesArtifacts: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,10 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+        version:
+          description: 'Version (e.g. v1.2.3)'
+          required: true
 
 jobs:
   build:
@@ -17,6 +21,11 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: '20'
+      - name: Set safe version
+        run: |
+          VERSION=${{ github.event.inputs.version || github.ref_name }}
+          SAFE_VERSION="${VERSION//\//-}"
+          echo "SAFE_VERSION=$SAFE_VERSION" >> $GITHUB_ENV
       - run: npm ci
       - run: npm run lint
       - run: npm run build
@@ -26,7 +35,7 @@ jobs:
           ls
           mkdir -p packages
           cd dist
-          zip -r "../packages/${PACKAGE_NAME}-${{ github.ref_name }}-chrome.zip" .
+          zip -r "../packages/${PACKAGE_NAME}-${SAFE_VERSION}-chrome.zip" .
           cd ..
       - name: Create Release
         uses: ncipollo/release-action@v1.12.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
       - run: npm run build
       - name: Package extension
         run: |
+          pwd
+          ls
           mkdir -p packages
           cd dist
           zip -r "../packages/${PACKAGE_NAME}-${{ github.ref_name }}-chrome.zip" .
@@ -29,7 +31,7 @@ jobs:
       - name: Create Release
         uses: ncipollo/release-action@v1.12.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           name: ${{ github.ref_name }}
           artifacts: "packages/${{ env.PACKAGE_NAME }}-${{ github.ref_name }}-chrome.zip"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          name: ${{ github.ref_name }}
-          artifacts: "packages/${{ env.PACKAGE_NAME }}-${{ github.ref_name }}-chrome.zip"
+          name: ${{ env.SAFE_VERSION }}
+          artifacts: "packages/${{ env.PACKAGE_NAME }}-${{ env.SAFE_VERSION }}-chrome.zip"
           tag: ${{ github.ref_name }}
           replacesArtifacts: true

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ And there's no plan at the moment to support this.
 
 ## Usage
 
-For now:
+Download the latest build from this repository's [releases](https://github.com/your-username/Dynamics-Launchpad/releases) page and unzip it. Then load the folder in `chrome://extensions` using "Load unpacked".
+
+Alternatively build from source:
 - Clone this repo
 - `npm i`
 - `npm run build`


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow using Node 20
- create zip packages and upload them as release assets
- update README with link to Releases page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68459abb6b488333b6e9c025c02fd478