### PR TITLE
Fix Backspace handling in spotlight

### DIFF
--- a/app/scripts/spotlight/ui.ts
+++ b/app/scripts/spotlight/ui.ts
@@ -412,14 +412,18 @@ async function openSpotlight(options?: { tip?: boolean }) {
     } else if (ev.key === 'ArrowUp') {
       select((selected?.previousElementSibling as HTMLLIElement) || list.lastElementChild);
       ev.preventDefault();
-    } else if (ev.key === 'Backspace' && input.value === '' && state === Step.EnvironmentInfoDisplay) {
+    } else if (ev.key === 'Backspace' && input.value === '' && pills.length > 0) {
       pills.pop();
-      state = Step.Commands;
-      filtered = commands;
-      input.placeholder = 'Search commands...';
-      input.style.display = '';
-      infoPanel.style.display = 'none';
-      list.style.display = '';
+      if (state === Step.OpenRecordId) {
+        state = Step.OpenRecordEntity;
+        input.placeholder = 'Search entity...';
+        filtered = metadata;
+      } else {
+        state = Step.Commands;
+        filtered = commands;
+        input.placeholder = 'Search commands...';
+        input.style.display = '';
+      }
       renderPills();
       render();
     } else if (ev.key === 'Enter') {


### PR DESCRIPTION
## Summary
- allow Backspace to navigate out of any spotlight sub-mode

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6845d7e9d2208333abc3ee47980161af