### PR TITLE
Add spotlight favourites

### DIFF
--- a/app/scripts/spotlight/ui.ts
+++ b/app/scripts/spotlight/ui.ts
@@ -214,21 +214,32 @@ async function openSpotlight(options?: { tip?: boolean }) {
 
   function renderFavorites() {
     favWrap.innerHTML = '';
-    if (pills.length > 0 || state !== Step.Commands) return;
-    favorites.forEach((id) => {
-      const cmd = commands.find((c) => c.id === id);
-      if (!cmd) return;
-      const div = document.createElement('div');
-      div.className = 'dl-fav';
-      const ic = document.createElement('span');
-      ic.className = 'material-icons dl-fav-icon';
-      ic.textContent = cmd.icon || commandIcons[cmd.id] || categoryIcons[cmd.category] || 'chevron_right';
-      const txt = document.createElement('span');
-      txt.textContent = cmd.title;
-      div.append(ic, txt);
-      div.addEventListener('click', () => executeCommand(cmd));
-      favWrap.append(div);
-    });
+    if (pills.length > 0 || state !== Step.Commands || favorites.size === 0) {
+      return;
+    }
+    Array.from(favorites)
+      .slice(0, 5)
+      .forEach((id) => {
+        const cmd = commands.find((c) => c.id === id);
+        if (!cmd) return;
+        const div = document.createElement('div');
+        div.className = 'dl-fav';
+
+        const iconWrap = document.createElement('div');
+        iconWrap.className = 'dl-fav-icon-wrap';
+        const ic = document.createElement('span');
+        ic.className = 'material-icons dl-fav-icon';
+        ic.textContent = cmd.icon || commandIcons[cmd.id] || categoryIcons[cmd.category] || 'chevron_right';
+        iconWrap.append(ic);
+
+        const txt = document.createElement('div');
+        txt.className = 'dl-fav-title';
+        txt.textContent = cmd.title;
+
+        div.append(iconWrap, txt);
+        div.addEventListener('click', () => executeCommand(cmd));
+        favWrap.append(div);
+      });
   }
 
   function render() {

--- a/app/scripts/spotlight/ui.ts
+++ b/app/scripts/spotlight/ui.ts
@@ -84,6 +84,36 @@ async function openSpotlight(options?: { tip?: boolean }) {
   const container = document.createElement('div');
   container.id = 'dl-spotlight-container';
 
+  function makeDraggable(el: HTMLElement) {
+    let offsetX = 0;
+    let offsetY = 0;
+    let dragging = false;
+
+    function move(ev: MouseEvent) {
+      if (!dragging) return;
+      el.style.transform = '';
+      el.style.left = `${ev.clientX - offsetX}px`;
+      el.style.top = `${ev.clientY - offsetY}px`;
+    }
+
+    function up() {
+      dragging = false;
+      document.removeEventListener('mousemove', move);
+      document.removeEventListener('mouseup', up);
+    }
+
+    el.addEventListener('mousedown', (ev) => {
+      if ((ev.target as HTMLElement).closest('.dl-fav')) return;
+      const rect = el.getBoundingClientRect();
+      offsetX = ev.clientX - rect.left;
+      offsetY = ev.clientY - rect.top;
+      dragging = true;
+      document.addEventListener('mousemove', move);
+      document.addEventListener('mouseup', up);
+      ev.preventDefault();
+    });
+  }
+
   const logo = document.createElement('img');
   logo.id = 'dl-spotlight-logo';
   logo.src = chrome.runtime.getURL('app/images/lp_ll.png');
@@ -105,6 +135,7 @@ async function openSpotlight(options?: { tip?: boolean }) {
   const favWrap = document.createElement('div');
   favWrap.id = 'dl-spotlight-favs';
   favWrap.style.display = 'none';
+  makeDraggable(favWrap);
   const pillWrap = document.createElement('div');
   pillWrap.id = 'dl-spotlight-pills';
   const input = document.createElement('input');

--- a/app/scripts/spotlight/ui.ts
+++ b/app/scripts/spotlight/ui.ts
@@ -104,6 +104,7 @@ async function openSpotlight(options?: { tip?: boolean }) {
   }
   const favWrap = document.createElement('div');
   favWrap.id = 'dl-spotlight-favs';
+  favWrap.style.display = 'none';
   const pillWrap = document.createElement('div');
   pillWrap.id = 'dl-spotlight-pills';
   const input = document.createElement('input');
@@ -120,14 +121,14 @@ async function openSpotlight(options?: { tip?: boolean }) {
   progress.id = 'dl-spotlight-progress';
   progress.innerHTML = '<div class="dl-spinner"></div><div class="dl-progress-text"></div>';
   const progressText = progress.querySelector<HTMLDivElement>('.dl-progress-text')!;
-  container.append(logo, favWrap, pillWrap, input, list, infoPanel, progress);
+  container.append(logo, pillWrap, input, list, infoPanel, progress);
+  backdrop.append(favWrap, container);
   if (options?.tip) {
     const tip = document.createElement('div');
     tip.textContent = 'Tip: Press Ctrl+Shift+P to open this window.';
     tip.className = 'dl-tip';
     container.append(tip);
   }
-  backdrop.append(container);
   backdrop.addEventListener('click', (e) => {
     if (e.target === backdrop) closeSpotlight();
   });
@@ -215,8 +216,10 @@ async function openSpotlight(options?: { tip?: boolean }) {
   function renderFavorites() {
     favWrap.innerHTML = '';
     if (pills.length > 0 || state !== Step.Commands || favorites.size === 0) {
+      favWrap.style.display = 'none';
       return;
     }
+    favWrap.style.display = 'flex';
     Array.from(favorites)
       .slice(0, 5)
       .forEach((id) => {

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -226,11 +226,11 @@
 /* Favorites UI */
 #dl-spotlight-favs {
   position: absolute;
-  top: 7%;
+  top: 4%;
   left: 50%;
   transform: translateX(-50%);
-  width: 500px;
-  padding: 5px 16px;
+  width: 527px;
+  padding: 5px 3px;
   background: rgba(255, 255, 255, 0.45);
   border-radius: 12px;
   backdrop-filter: blur(9px);

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -222,3 +222,32 @@
 #dl-auto-reload-toast button.selected {
   background: #777 !important;
 }
+
+/* Favorites UI */
+#dl-spotlight-favs {
+  margin-bottom: 6px;
+}
+
+.dl-fav {
+  display: inline-flex;
+  align-items: center;
+  background: #f3e8fc;
+  border-radius: 8px;
+  padding: 2px 6px;
+  margin-right: 4px;
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.dl-fav-icon {
+  margin-right: 4px;
+  color: #a631af;
+  font-size: 14px;
+}
+
+.dl-star {
+  margin-left: auto;
+  cursor: pointer;
+  color: #a631af;
+  font-size: 16px;
+}

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -225,11 +225,16 @@
 
 /* Favorites UI */
 #dl-spotlight-favs {
-  margin-bottom: 6px;
-  padding: 6px;
-  background: #f9f0ff;
-  border-radius: 10px;
-  display: flex;
+  position: absolute;
+  top: calc(20% - 72px);
+  left: 50%;
+  transform: translateX(-50%);
+  width: 500px;
+  padding: 8px;
+  background: rgba(255, 255, 255, 0.45);
+  border-radius: 12px;
+  backdrop-filter: blur(9px);
+  display: none;
   gap: 8px;
   justify-content: flex-start;
 }

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -237,6 +237,8 @@
   display: none;
   gap: 0;
   justify-content: flex-start;
+  cursor: move;
+  user-select: none;
 }
 
 .dl-fav {
@@ -247,6 +249,7 @@
   line-height: 1.2;
   padding: 8px;
   border-radius: 10px;
+  user-select: none;
 }
 
 .dl-fav:hover {
@@ -263,11 +266,13 @@
   background: #f3e8fc;
   border-radius: 8px;
   margin-bottom: 4px;
+  user-select: none;
 }
 
 .dl-fav-icon {
   color: #a631af;
   font-size: 24px;
+  user-select: none;
 }
 
 .dl-fav-title {
@@ -278,6 +283,7 @@
   -webkit-line-clamp: 2;
   color: black;
   font-size: 12px;
+  user-select: none;
 }
 
 .dl-star {
@@ -287,6 +293,7 @@
   font-size: 16px;
   border-radius: 4px;
   padding: 2px;
+  user-select: none;
 }
 
 .dl-star:hover {

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -237,7 +237,6 @@
   display: none;
   gap: 0;
   justify-content: flex-start;
-  cursor: move;
   user-select: none;
 }
 
@@ -245,11 +244,15 @@
   width: 50px;
   font-size: 11px;
   text-align: center;
-  cursor: pointer;
+  cursor: grab;
   line-height: 1.2;
   padding: 8px;
   border-radius: 10px;
   user-select: none;
+}
+
+.dl-fav:active {
+  cursor: grabbing;
 }
 
 .dl-fav:hover {

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -178,7 +178,6 @@
   }
 }
 
-
 .dl-toast {
   position: fixed;
   bottom: 20px;
@@ -191,6 +190,7 @@
   z-index: 2147483647;
   opacity: 0;
   transition: opacity 0.3s;
+}
 
 #dl-auto-reload-toast button {
   font-size: 12px;
@@ -226,23 +226,44 @@
 /* Favorites UI */
 #dl-spotlight-favs {
   margin-bottom: 6px;
+  padding: 6px;
+  background: #f9f0ff;
+  border-radius: 10px;
+  display: flex;
+  gap: 8px;
+  justify-content: flex-start;
 }
 
 .dl-fav {
-  display: inline-flex;
+  width: 50px;
+  font-size: 11px;
+  text-align: center;
+  cursor: pointer;
+  line-height: 1.2;
+}
+
+.dl-fav-icon-wrap {
+  width: 50px;
+  height: 50px;
+  display: flex;
   align-items: center;
+  justify-content: center;
   background: #f3e8fc;
   border-radius: 8px;
-  padding: 2px 6px;
-  margin-right: 4px;
-  font-size: 12px;
-  cursor: pointer;
+  margin-bottom: 4px;
 }
 
 .dl-fav-icon {
-  margin-right: 4px;
   color: #a631af;
-  font-size: 14px;
+  font-size: 24px;
+}
+
+.dl-fav-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
 .dl-star {
@@ -250,4 +271,10 @@
   cursor: pointer;
   color: #a631af;
   font-size: 16px;
+  border-radius: 4px;
+  padding: 2px;
+}
+
+.dl-star:hover {
+  background: rgba(166, 49, 175, 0.1);
 }

--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -226,16 +226,16 @@
 /* Favorites UI */
 #dl-spotlight-favs {
   position: absolute;
-  top: calc(20% - 72px);
+  top: 7%;
   left: 50%;
   transform: translateX(-50%);
   width: 500px;
-  padding: 8px;
+  padding: 5px 16px;
   background: rgba(255, 255, 255, 0.45);
   border-radius: 12px;
   backdrop-filter: blur(9px);
   display: none;
-  gap: 8px;
+  gap: 0;
   justify-content: flex-start;
 }
 
@@ -245,6 +245,13 @@
   text-align: center;
   cursor: pointer;
   line-height: 1.2;
+  padding: 8px;
+  border-radius: 10px;
+}
+
+.dl-fav:hover {
+  background: #e7c9fd;
+  color: white;
 }
 
 .dl-fav-icon-wrap {
@@ -269,6 +276,8 @@
   display: -webkit-box;
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 2;
+  color: black;
+  font-size: 12px;
 }
 
 .dl-star {


### PR DESCRIPTION
## Summary
- add ability to star commands in spotlight
- display favourites above the search bar

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6847dc3218488333b34557f79b3529b3