### PR TITLE
Improve spotlight favourites UI

### DIFF
--- a/app/styles/spotlight.css
+++ b/app/styles/spotlight.css
@@ -178,7 +178,6 @@
   }
 }
 
-
 .dl-toast {
   position: fixed;
   bottom: 20px;
@@ -191,6 +190,7 @@
   z-index: 2147483647;
   opacity: 0;
   transition: opacity 0.3s;
+}
 
 #dl-auto-reload-toast button {
   font-size: 12px;
@@ -221,4 +221,123 @@
 
 #dl-auto-reload-toast button.selected {
   background: #777 !important;
+}
+
+/* Favorites UI */
+#dl-spotlight-favs {
+  position: absolute;
+  top: 4%;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 527px;
+  padding: 5px 3px;
+  background: rgba(255, 255, 255, 0.45);
+  border-radius: 12px;
+  backdrop-filter: blur(9px);
+  display: none;
+  gap: 0;
+  justify-content: flex-start;
+  user-select: none;
+}
+
+.dl-fav {
+  position: relative;
+  width: 50px;
+  font-size: 11px;
+  text-align: center;
+  cursor: grab;
+  line-height: 1.2;
+  padding: 8px;
+  border-radius: 10px;
+  user-select: none;
+}
+
+.dl-fav:active {
+  cursor: grabbing;
+}
+
+.dl-fav:hover {
+  background: #e7c9fd;
+  color: white;
+}
+
+.dl-fav-icon-wrap {
+  width: 50px;
+  height: 50px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #f3e8fc;
+  border-radius: 8px;
+  margin-bottom: 4px;
+  user-select: none;
+}
+
+.dl-fav-brush {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  font-size: 14px;
+  cursor: pointer;
+  display: none;
+  color: #555;
+  background: rgba(255, 255, 255, 0.8);
+  border-radius: 4px;
+  padding: 1px;
+}
+
+.dl-fav:hover .dl-fav-brush {
+  display: block;
+}
+
+.dl-color-picker {
+  position: absolute;
+  top: 20px;
+  right: 2px;
+  display: flex;
+  background: white;
+  border-radius: 6px;
+  padding: 4px;
+  gap: 4px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
+  z-index: 1;
+}
+
+.dl-color-option {
+  width: 16px;
+  height: 16px;
+  border-radius: 4px;
+  cursor: pointer;
+  border: 1px solid #ccc;
+}
+
+.dl-fav-icon {
+  color: #a631af;
+  font-size: 24px;
+  user-select: none;
+}
+
+.dl-fav-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  color: black;
+  font-size: 12px;
+  user-select: none;
+}
+
+.dl-star {
+  margin-left: auto;
+  cursor: pointer;
+  color: #a631af;
+  font-size: 16px;
+  border-radius: 4px;
+  padding: 2px;
+  user-select: none;
+}
+
+.dl-star:hover {
+  background: rgba(166, 49, 175, 0.1);
 }


### PR DESCRIPTION
## Summary
- refine favourites panel style and placement
- improve favourite item hover styling
- keep star styles unchanged
- make favourites draggable and disable selection
- allow favourites reorder by drag and update star toggle logic
- update favourite container positioning
- allow colour customisation of favourites and increase limit to eight

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6847dc3218488333b34557f79b3529b3